### PR TITLE
Message history

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Things I've learned
 * postcss - tailwind can be installed as a postCSS plugin which helps integrate it with build tools like webpack and Vite, postCSS is a preprocessor<sup>[[4]](https://tailwindcss.com/docs/using-with-preprocessors)</sup> so that the CSS will be compiled quicker by allowing you to parse/read a css file written in a different syntax and converting it into plain CSS. This makes writing CSS faster, easier, and more modular <sup>[[5]](https://www.google.com/search?q=is+postcss+like+sass&rlz=1C1RXQR_enUS1044US1044&oq=is+postcss+like+sass&aqs=chrome..69i57.3565j0j1&sourceid=chrome&ie=UTF-8)</sup><sup>[[6]](https://github.com/postcss/postcss)</sup>
 * autoprefixer - a postCSS plugin that parses CSS and add [vendor prefixes](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix) to CSS rules <sup>[[7]](https://github.com/postcss/autoprefixer)</sup>
 
+**Heartbeat refresh: https://www.reddit.com/r/reactjs/comments/erbwyq/best_practices_for_a_heartbeat_refresh/**
+
+
 * [Making superscripts in markdown files](https://stackoverflow.com/questions/15155778/superscript-in-markdown-github-flavored) credit goes to [Michael Wild on Stack Overflow](https://stackoverflow.com/users/159834/michael-wild)
 
 * JWT Error: secretOrPrivateKey must have a value resolved by [Rabo Yusuf on Stack Overflow](https://stackoverflow.com/users/12221293/rabo-yusuf): <br></br> https://stackoverflow.com/questions/58673430/error-secretorprivatekey-must-have-a-value

--- a/api/index.js
+++ b/api/index.js
@@ -51,7 +51,7 @@ app.get('/messages/:userId', async (req, res) => {
     const messages = await Message.find({
         sender: { $in: [userId, ourUserId] },
         recipient: { $in: [userId, ourUserId] },
-    }).sort({ createdAt: -1 });
+    }).sort({ createdAt: 1 }); //Sorts in ascending order (first message on top, latest message on bottom)
     res.json(messages);
 });
 
@@ -147,7 +147,7 @@ wss.on('connection', (connection, req) => {
                     text,
                     sender: connection.userId,
                     recipient,
-                    id: messageDoc._id,
+                    _id: messageDoc._id,
                 })));
         }
     });

--- a/api/index.js
+++ b/api/index.js
@@ -23,8 +23,36 @@ app.use(cors({
     origin: process.env.CLIENT_URL,
 }));
 
+
+// Function to obtain userData from token
+async function getUserDataFromRequest(req) {
+    return new Promise((resolve, reject) => {
+        const token = req.cookies?.token;
+        if (token) {
+            jwt.verify(token, jwtSecret, {}, (err, userData) => {
+                if (err) throw err;
+                resolve(userData);
+            });
+        } else {
+            reject('no token');
+        }
+    })
+
+}
+
 app.get('/test', (req, res) => {
     res.json('test ok');
+});
+
+app.get('/messages/:userId', async (req, res) => {
+    const { userId } = req.params;
+    const userData = await getUserDataFromRequest(req);
+    const ourUserId = userData.userId;
+    const messages = await Message.find({
+        sender: { $in: [userId, ourUserId] },
+        recipient: { $in: [userId, ourUserId] },
+    }).sort({ createdAt: -1 });
+    res.json(messages);
 });
 
 app.get('/profile', (req, res) => {

--- a/client/src/Chat.jsx
+++ b/client/src/Chat.jsx
@@ -23,7 +23,12 @@ export default function Chat() {
         const ws = new WebSocket('ws://localhost:4000');
         setWs(ws);
         ws.addEventListener('message', handleMessage);
-        ws.addEventListener('close', () => connectToWS());
+        ws.addEventListener('close', () => {
+            setTimeout(() => {
+                console.log('Disconnected. Trying to reconnect.');
+                connectToWS();
+            }, 1000)
+        });
     }
 
     // reduces the data of who is online to unique values only

--- a/client/src/Chat.jsx
+++ b/client/src/Chat.jsx
@@ -16,10 +16,15 @@ export default function Chat() {
     const divUnderMessages = useRef();
 
     useEffect(() => {
+        connectToWS()
+    }, []);
+
+    function connectToWS() {
         const ws = new WebSocket('ws://localhost:4000');
         setWs(ws);
-        ws.addEventListener('message', handleMessage)
-    }, []);
+        ws.addEventListener('message', handleMessage);
+        ws.addEventListener('close', () => connectToWS());
+    }
 
     // reduces the data of who is online to unique values only
     // for each object (user) that is online, there is a new object whose key: value pair is the userId (key) and the username (value)

--- a/client/src/Chat.jsx
+++ b/client/src/Chat.jsx
@@ -3,6 +3,7 @@ import { UserContext } from "./UserContext.jsx";
 import Avatar from "./Avatar";
 import Logo from "./Logo";
 import { uniqBy } from 'lodash';
+import axios from "axios";
 
 export default function Chat() {
     const [ws, setWs] = useState(null);
@@ -73,6 +74,13 @@ export default function Chat() {
             div.scrollIntoView({ behavior: 'smooth', block: 'end' });
         }
     }, [messages])
+
+    // This effect occurs when there's a change to the selectedUserId and if the value isn't null (default upon load because no conversation is selected)
+    useEffect(() => {
+        if (selectedUserId) {
+            axios.get('/messages/' + selectedUserId)
+        }
+    }, [selectedUserId])
 
     const onlinePeopleThatsNotUs = { ...onlinePeople };
     delete onlinePeopleThatsNotUs[id];

--- a/client/src/Chat.jsx
+++ b/client/src/Chat.jsx
@@ -51,7 +51,6 @@ export default function Chat() {
         if ('online' in messageData) {
             showOnlinePeople(messageData.online);
         } else if ('text' in messageData) {
-            // isOur: false means it not our message but the other party's (incoming message)
             setMessages(prevMessage => ([...prevMessage, { ...messageData }]));
         }
     }
@@ -64,12 +63,11 @@ export default function Chat() {
         }));
         // Resets state to empty string after message is sent, thus clearing the message input from the form
         setNewMessageText('');
-        // isOur: true means it our message (outgoing message)
         setMessages(prevMessage => ([...prevMessage, {
             text: newMessageText,
             sender: id,
             recipient: selectedUserId,
-            id: Date.now(),
+            _id: Date.now(),
         }]));
     }
 
@@ -88,7 +86,9 @@ export default function Chat() {
     // This effect occurs when there's a change to the selectedUserId and if the value isn't null (default upon load because no conversation is selected)
     useEffect(() => {
         if (selectedUserId) {
-            axios.get('/messages/' + selectedUserId)
+            axios.get('/messages/' + selectedUserId).then(res => {
+                setMessages(res.data);
+            })
         }
     }, [selectedUserId])
 
@@ -96,7 +96,7 @@ export default function Chat() {
     delete onlinePeopleThatsNotUs[id];
 
     // Prevents duplicate messages
-    const uniqueMessages = uniqBy(messages, 'id');
+    const uniqueMessages = uniqBy(messages, '_id');
 
     return (
         <div className="flex h-screen">
@@ -130,10 +130,8 @@ export default function Chat() {
                         <div className="relative h-full">
                             <div className="overflow-y-scroll absolute top-0 left-0 right-0 bottom-2">
                                 {uniqueMessages.map(message => (
-                                    <div key={message.id} className={(message.sender === id ? "text-right" : "text-left")}>
+                                    <div key={message._id} className={(message.sender === id ? "text-right" : "text-left")}>
                                         <div className={"text-left inline-block p-2 my-2 rounded-md text-sm " + (message.sender === id ? 'bg-blue-500 text-white' : 'bg-white text-gray-500')}>
-                                            sender:{message.sender}<br></br>
-                                            my id: {id}<br></br>
                                             {message.text}
                                         </div>
                                     </div>


### PR DESCRIPTION
This update allows users to see their past messages that were previously stored in MongoDB along with new ones sent during the current session. This update also adds a recursive function to reconnect the user should there be any event where the connection is lost.

Files changed:
1. README.md - Edited, added new concept learnt, heartbeat refresh
2. api/index.js - Edited, added route to obtain messages and userId from token, renamed `id` to `_id` on line 150 (formerly 122)
3. client/src/Chat.jsx - Edited, added connect to WebSocket function to occur when disconnected (`close` event), renamed `id` to `_id` on line 70  (formerly 61) and line 99 (formerly 81) and line 133 (formerly 115), added useEffect to get messages from database when selecting a user, took out message.sender and user.id from message boxes

Tested on Chrome, Edge